### PR TITLE
Do not include whitespace when applying inline markdown styles

### DIFF
--- a/src/stateToMarkdown.js
+++ b/src/stateToMarkdown.js
@@ -19,6 +19,7 @@ const {
 } = INLINE_STYLE;
 
 const CODE_INDENT = '    ';
+const STRIP_WHITESPACE = /([\s]*)([\W\w]*[^\s]+)([\s]*)/;
 
 class MarkupGenerator {
   blocks: Array<ContentBlock>;
@@ -201,21 +202,21 @@ class MarkupGenerator {
         }
         let content = encodeContent(text);
         if (style.has(BOLD)) {
-          content = `**${content}**`;
+          content = content.replace(STRIP_WHITESPACE, '$1**$2**$3');
         }
         if (style.has(UNDERLINE)) {
           // TODO: encode `+`?
-          content = `++${content}++`;
+          content = content.replace(STRIP_WHITESPACE, '$1++$2++$3');
         }
         if (style.has(ITALIC)) {
-          content = `_${content}_`;
+          content = content.replace(STRIP_WHITESPACE, '$1_$2_$3');
         }
         if (style.has(STRIKETHROUGH)) {
           // TODO: encode `~`?
-          content = `~~${content}~~`;
+          content = content.replace(STRIP_WHITESPACE, '$1~~$2~~$3');
         }
         if (style.has(CODE)) {
-          content = (blockType === BLOCK_TYPE.CODE) ? content : '`' + content + '`';
+          content = (blockType === BLOCK_TYPE.CODE) ? content : content.replace(STRIP_WHITESPACE, '$1`$2`$3');
         }
         return content;
       }).join('');

--- a/test/test-cases.txt
+++ b/test/test-cases.txt
@@ -6,9 +6,17 @@ a
 {"entityMap":{},"blocks":[{"key":"99n0j","text":"asdf","type":"unstyled","depth":0,"inlineStyleRanges":[{"offset":3,"length":1,"style":"BOLD"}],"entityRanges":[]}]}
 asd**f**
 
+>> Inline style with whitespace
+{"entityMap":{},"blocks":[{"key":"99n0j","text":"asdf  ","type":"unstyled","depth":0,"inlineStyleRanges":[{"offset":0,"length":6,"style":"BOLD"}],"entityRanges":[]}]}
+**asdf**  
+
 >> Nested Inline Style
 {"entityMap":{},"blocks":[{"key":"9nc73","text":"BoldItalic","type":"unstyled","depth":0,"inlineStyleRanges":[{"offset":0,"length":10,"style":"BOLD"},{"offset":0,"length":10,"style":"ITALIC"}],"entityRanges":[]}]}
 _**BoldItalic**_
+
+>> Nested Inline Style with whitespace
+{"entityMap":{},"blocks":[{"key":"9nc73","text":"BoldItalic    ","type":"unstyled","depth":0,"inlineStyleRanges":[{"offset":0,"length":14,"style":"BOLD"},{"offset":0,"length":10,"style":"ITALIC"}],"entityRanges":[]}]}
+_**BoldItalic**_    
 
 >> Adjacent Inline Style
 {"entityMap":{},"blocks":[{"key":"9nc73","text":"BoldItalic","type":"unstyled","depth":0,"inlineStyleRanges":[{"offset":4,"length":6,"style":"BOLD"},{"offset":0,"length":4,"style":"ITALIC"}],"entityRanges":[]}]}


### PR DESCRIPTION
If you test out markdown on a gist, markdown like this:

``` markdown
**Test **
```

(with trailing or leading whitespace) is not properly parsed.

This change only surrounds the text with markdown inline styles and preserves
the whitespace, but doesn't attempt to style it, fixing the issue of
incompatibility with markdown parsers.
